### PR TITLE
Add new notes at the beginning of notes lists

### DIFF
--- a/src/usernotes.ts
+++ b/src/usernotes.ts
@@ -197,7 +197,7 @@ export class UsernotesData {
 		if (link) {
 			newNote.l = squashPermalink(link);
 		}
-		this.users[username].ns.push(newNote);
+		this.users[username].ns.unshift(newNote);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #16. Toolbox itself does write its new notes to the beginning of the notes array, so we need to be consistent.

https://github.com/toolbox-team/reddit-moderator-toolbox/blob/4d8d2a497347d2cd4c56f571175b91e4478dcb86/extension/data/modules/usernotes.js#L640