### PR TITLE
Check for lowercased usernote entries when reading

### DIFF
--- a/src/classes/Usernotes.test.ts
+++ b/src/classes/Usernotes.test.ts
@@ -1,9 +1,74 @@
 import test from 'ava';
 import {Usernotes} from './Usernotes';
+import {compressBlob, decompressBlob} from '../helpers/usernotes';
+import type {RawUsernotes} from '../types/RawUsernotes';
 
 test.todo('constructor');
 
-test.todo('get');
+test.todo('get: most other things');
+
+test('get: read and merge existing entries for lowercased usernames', t => {
+	let rawUsernotes: RawUsernotes = {
+		ver: 6,
+		constants: {
+			users: ['someMod'],
+			warnings: [],
+		},
+		blob: compressBlob({
+			someuser: {
+				ns: [
+					{
+						m: 0,
+						n: 'test 0',
+						t: 0,
+					},
+					{
+						m: 0,
+						n: 'test 2',
+						t: 2,
+					},
+				],
+			},
+			someUser: {
+				ns: [
+					{
+						m: 0,
+						n: 'test 1',
+						t: 1,
+					},
+					{
+						m: 0,
+						n: 'test 3',
+						t: 3,
+					},
+				],
+			},
+		}),
+	};
+	let usernotes = new Usernotes(JSON.stringify(rawUsernotes));
+
+	let notes = usernotes.get('someUser');
+
+	// expect notes under both variants of the username to be present and sorted
+	t.like(notes, [
+		{
+			text: 'test 3',
+		},
+		{
+			text: 'test 2',
+		},
+		{
+			text: 'test 1',
+		},
+		{
+			text: 'test 0'
+		},
+	], 'notes from both spellings of the username should be returned in order');
+
+	// expect the entry under the lowercased username to be gone when saving
+	const newUsersData = decompressBlob(usernotes.toJSON().blob);
+	t.false('someuser' in newUsersData, 'lowercased spelling of the username should be removed from usernotes object');
+})
 
 test.todo('add');
 

--- a/src/classes/Usernotes.ts
+++ b/src/classes/Usernotes.ts
@@ -96,7 +96,7 @@ export class Usernotes {
 		// property of each to the canonical username, and push them into the
 		// canonical list of notes. Then, completely remove the entry under the
 		// lowercased username so it will be removed if we save to wiki later.
-                const otherNotes = this.users.get(usernameLowercase) || [];
+		const otherNotes = this.users.get(usernameLowercase) || [];
 		const updatedNotes = otherNotes.map(note => ({
 			...note,
 			username,

--- a/src/classes/Usernotes.ts
+++ b/src/classes/Usernotes.ts
@@ -96,11 +96,12 @@ export class Usernotes {
 		// property of each to the canonical username, and push them into the
 		// canonical list of notes. Then, completely remove the entry under the
 		// lowercased username so it will be removed if we save to wiki later.
-		const otherNotes = (this.users.get(usernameLowercase) || []).map(note => ({
+                const otherNotes = this.users.get(usernameLowercase) || [];
+		const updatedNotes = otherNotes.map(note => ({
 			...note,
 			username,
 		}));
-		notes.push(...otherNotes);
+		notes.push(...updatedNotes);
 		this.users.delete(usernameLowercase);
 
 		// the two note lists might overlap in date range; sort in place


### PR DESCRIPTION
Fixes #49. When getting notes for a given username, assume that the name we're given is the canonical spelling, and if there's an existing entry in `users` for the lowercased version of the username, remove it and merge its notes into the canonical entry.

This is something that can't really be done ahead of time in the constructor, like schema migrations are done. Because of the way Reddit usernames work, we know that every entry that `toLowerCase()`s to the same value refers to the same user; however, we don't strictly speaking know which spelling of the name is canonical until the API consumer gives us that information. That's why this is done within `.get()` instead.