### PR TITLE
Accept empty input to Usernotes constructor

### DIFF
--- a/src/classes/Usernotes.test.ts
+++ b/src/classes/Usernotes.test.ts
@@ -3,7 +3,19 @@ import {compressBlob, decompressBlob} from '../helpers/usernotes';
 import type {RawUsernotes} from '../types/RawUsernotes';
 import {Usernotes} from './Usernotes';
 
-test.todo('constructor');
+test('constructor: accept empty input', t => {
+	t.assert(
+		new Usernotes() instanceof Usernotes,
+		'passing nothing to Usernotes constructor should return a Usernotes instance',
+	);
+
+	t.assert(
+		new Usernotes('') instanceof Usernotes,
+		'passing empty string to Usernotes constructor should return a Usernotes instance',
+	);
+});
+
+test.todo('constructor: most other things');
 
 test.todo('get: most other things');
 

--- a/src/classes/Usernotes.ts
+++ b/src/classes/Usernotes.ts
@@ -9,10 +9,6 @@ import {
 import {RawUsernotes, RawUsernotesConstants} from '../types/RawUsernotes';
 import {Usernote} from '../types/Usernote';
 
-// TODO: nothing here handles username case correctly; go back and check the
-//       toolbox implementation of that for correctness later and write test
-//       cases for it
-
 /**
  * A class that interfaces with the raw contents of a subreddit's `usernotes`
  * wiki page, automatically upgrading old storage schemas to the current version

--- a/src/classes/Usernotes.ts
+++ b/src/classes/Usernotes.ts
@@ -19,7 +19,12 @@ export class Usernotes {
 	/** A mapping of usernames to notes on the given user. */
 	private users = new Map<string, Usernote[]>();
 
-	constructor (jsonString: string) {
+	constructor (jsonString?: string) {
+		// if we have no data to start with, we start fresh
+		if (!jsonString) {
+			return;
+		}
+
 		let data = migrateUsernotesToLatestSchema(JSON.parse(jsonString));
 		const rawUsers = decompressBlob(data.blob);
 


### PR DESCRIPTION
Part of #58 but only handles `Usernotes`; it's not immediately obvious how to handle empty input for `SubredditConfig` because the defaults for that file are scattered throughout Toolbox.

Ensures `new Usernotes()` and `new Usernotes('')` work as expected, returning valid instances with no stored notes.